### PR TITLE
Add rows for transparent colors to storybook

### DIFF
--- a/storybook/stories/Brand/Colors.stories.tsx
+++ b/storybook/stories/Brand/Colors.stories.tsx
@@ -27,7 +27,7 @@ storiesOf("Brand/Colors", module)
             return (
               <View
                 style={{ height: 60, margin: 8, width: "14.28%", backgroundColor: color }}
-                key={color + index.toString()}
+                key={index.toString()}
               />
             );
           })}
@@ -37,7 +37,7 @@ storiesOf("Brand/Colors", module)
             return (
               <View
                 style={{ height: 60, margin: 8, width: "14.28%", backgroundColor: color }}
-                key={color + index.toString()}
+                key={index.toString()}
               />
             );
           })}

--- a/storybook/stories/Brand/Colors.stories.tsx
+++ b/storybook/stories/Brand/Colors.stories.tsx
@@ -5,6 +5,7 @@ import CenterView from "../../helpers/CenterView.react";
 import { ScrollView, View } from "react-native";
 
 const colorsArray = Object.values(Colors);
+const BACKGROUND_COLOR = "rgba(200, 226, 246, 1)";
 
 storiesOf("Brand/Colors", module)
   .addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
@@ -20,6 +21,31 @@ storiesOf("Brand/Colors", module)
               />
             );
           })}
+        </View>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", backgroundColor: BACKGROUND_COLOR }}>
+          {[Colors.BLACK, Colors.BLACK_65, Colors.BLACK_45, Colors.BLACK_25, Colors.BLACK_06].map((color, index) => {
+            return (
+              <View
+                style={{ height: 60, margin: 8, width: "14.28%", backgroundColor: color }}
+                key={color + index.toString()}
+              />
+            );
+          })}
+        </View>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", backgroundColor: BACKGROUND_COLOR }}>
+          {[Colors.WHITE, Colors.WHITE_65, Colors.WHITE_45, Colors.WHITE_25].map((color, index) => {
+            return (
+              <View
+                style={{ height: 60, margin: 8, width: "14.28%", backgroundColor: color }}
+                key={color + index.toString()}
+              />
+            );
+          })}
+        </View>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", backgroundColor: BACKGROUND_COLOR }}>
+          <View
+            style={{ height: 60, margin: 8, width: "14.28%", backgroundColor: Colors.WHITE_BACKGROUND }}
+          />
         </View>
       </ScrollView>
     );


### PR DESCRIPTION
* These already get displayed in the palate, but are added again with a blue background for clarity (reflecting Figma).

* Not included is the brand Gradient Red/Blue. `View` doesn't support the `background` style property (only `backgroundColor`), so figuring out where to express this gradient in the components library and storybook is WIP.

Figma link: https://www.figma.com/file/4EMXrcthXd1CwZYBik3uGz/V1-Rebrand-of-Mobile-Design-Library-(August-2021)?node-id=954%3A58197

Also forthcoming: screencaps from a mobile emulator for easier PR review. 