### PR TITLE
Match ContactCard to new design

### DIFF
--- a/src/Cards/ContactCard.react.tsx
+++ b/src/Cards/ContactCard.react.tsx
@@ -21,46 +21,38 @@ interface Props {
   picture?: JSX.Element;
   titleColor?: string;
   subtitleColor?: string;
-  size?: "small" | "large";
   touchable?: boolean;
+  elevated?: boolean;
   onPress?: (() => void) | (() => Promise<void>);
 }
 
 const Styles = StyleSheet.create({
-  smallBackground: {
-    flexDirection: "row",
-    ...Spacing.padding,
-    ...Spacing.marginBottom,
-    borderWidth: 2,
-    borderColor: Colors.GRAY_200,
-    backgroundColor: Colors.WHITE_BACKGROUND,
-    ...GlobalStyles.rounded,
-    alignItems: "center",
+  elevatedBorder: {
+    ...GlobalStyles.shadow,
   },
-  largeBackground: {
+  flatBorder: {
+    borderWidth: 2,
+    borderColor: Colors.BLACK_06,
+
+  },
+  background: {
     flexDirection: "row",
     ...Spacing.largePadding,
-    ...Spacing.largeMarginBottom,
-    backgroundColor: Colors.WHITE_BACKGROUND,
+    ...Spacing.marginBottom,
+    backgroundColor: Colors.WHITE,
     ...GlobalStyles.rounded,
-    ...GlobalStyles.shadow,
     alignItems: "center",
   },
   textContainer: {
     flex: 1,
   },
-  smallImageContainer: {
+  imageContainer: {
     width: 40,
     height: 40,
     borderRadius: 20,
     overflow: "hidden",
   },
-  largeImageContainer: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    overflow: "hidden",
-  },
+
 });
 
 const ContactCard: React.FC<Props> = ({
@@ -70,15 +62,15 @@ const ContactCard: React.FC<Props> = ({
   picture,
   titleColor,
   subtitleColor,
-  size,
   touchable,
+  elevated,
   onPress,
 }: Props) => {
   return (
     <TouchableOpacity
       disabled={!touchable}
       activeOpacity={touchable ? undefined : 1.0}
-      style={size === "large" ? Styles.largeBackground : Styles.smallBackground}
+      style={[Styles.background, elevated ? Styles.elevatedBorder : Styles.flatBorder]}
       onPress={() => {
         if (onPress) onPress();
       }}
@@ -88,9 +80,7 @@ const ContactCard: React.FC<Props> = ({
           source={{ uri }}
           viewStyle={[
             Spacing.largeMarginRight,
-            size === "large"
-              ? Styles.largeImageContainer
-              : Styles.smallImageContainer,
+            Styles.imageContainer,
           ]}
         />
       )}
@@ -106,10 +96,10 @@ const ContactCard: React.FC<Props> = ({
         />
       )}
       <View style={Styles.textContainer}>
-        <Body size={size === "large" ? 2 : 3} bold color={titleColor || "dark"}>
+        <Body size={3} bold color={titleColor || "dark"}>
           {getFullName(persona)}
         </Body>
-        <Body size={size === "large" ? 2 : 3} color={subtitleColor || "dark"}>
+        <Body size={3} color={subtitleColor || "dark"} style={{ marginTop: -2 }}>
           {subtitle}
         </Body>
       </View>

--- a/storybook/stories/Cards/Cards.stories.tsx
+++ b/storybook/stories/Cards/Cards.stories.tsx
@@ -18,31 +18,32 @@ storiesOf("Cards", module)
     <View style={{ width: "100%", padding: 16 }}>
       <ContactCard
         persona={{
-          firstName: text("First Name", "First"),
-          lastName: text("Last Name", "Last"),
+          firstName: "Firstname",
+          lastName: "Lastname",
         }}
-        subtitle={text("Facility", "Facility")}
-        size={radios("Size", { small: "small", large: "large" }, "small")}
-        uri="https://www.colorlines.com/sites/default/files/styles/article_lead_normal/public/2021-02/Uzoma-CL-02162020.jpg?itok=zye95qjg"
+        subtitle={"Facility name, SC"}
       />
       <ContactCard
         persona={{
-          firstName: "first",
-          lastName: "last",
+          firstName: text("First Name", "First"),
+          lastName: text("Last Name", "Last"),
         }}
-        subtitle={"no image"}
-        size="small"
+        subtitle={text("Facility name, SC", "Facility")}
+        elevated={true}
+        uri="https://www.colorlines.com/sites/default/files/styles/article_lead_normal/public/2021-02/Uzoma-CL-02162020.jpg?itok=zye95qjg"
       />
     </View>
   ))
   .add("LargeVerticalCard", () => (
     <View style={{ width: "100%", padding: 16 }}>
       <LargeVerticalCard
-        containerStyle={{width: 320,
+        containerStyle={{
+          width: 320,
           height: 200,
           ...Spacing.smallMargin,
           ...Spacing.smallPadding,
-          borderRadius: 100}}
+          borderRadius: 100
+        }}
         title={'Letter'}
         subtitle={'2000 words, collages, & more'}
         image={Photocard}
@@ -54,26 +55,30 @@ storiesOf("Cards", module)
   .add("HeaderCard", () => (
     <View style={{ width: "100%", padding: 16 }}>
       <HeaderCard
-        containerStyle={{width: 320,
-          height: 70}}
+        containerStyle={{
+          width: 320,
+          height: 70
+        }}
         title={'Header Emphasis'}
         subtitle={'Description text goes here'}
         img={Thumbnail}
         emphasis={'header'}
       />
-      <View style={{height: 20}}></View>
+      <View style={{ height: 20 }}></View>
       <HeaderCard
-        containerStyle={{width: 320,
-          height: 70}}
+        containerStyle={{
+          width: 320,
+          height: 70
+        }}
         title={'Header text'}
         subtitle={'Description text goes here'}
-        
+
         img={Thumbnail}
       />
-      <View style={{height: 20}}></View>
+      <View style={{ height: 20 }}></View>
 
       <HeaderCard
-        containerStyle={{height: 70}}
+        containerStyle={{ height: 70 }}
         title={'Body Emphasis'}
         subtitle={'Emphasized text description with lots of extra text that gets cut off'}
         img={Thumbnail}
@@ -87,7 +92,7 @@ storiesOf("Cards", module)
         text={'One Line Card - Regular'}
         img={OrangeBook}
       />
-      <View style={{height: 20}}></View>
+      <View style={{ height: 20 }}></View>
       <OneLineCard
         text={'One Line Card - Special'}
         img={WhiteBook}
@@ -95,8 +100,8 @@ storiesOf("Cards", module)
       />
     </View>
   ))
-  
-  
-  
-  
+
+
+
+
 


### PR DESCRIPTION
Changes:
 * Remove `size` (small/large) as a prop. All instances of ContactCard are small but this is a breaking change while instances in `letters-mobile` set the `size` prop.
 * New optional 'elevated' boolean prop. This determines whether the card has a flat 2px border or a shadow.
 * Use a -2px margin to achieve narrower space between Title and subtitle. This was a "visual fidelity over clean code" decision.