### PR TITLE
Shrink the vertical padding if an icon is present

### DIFF
--- a/src/UserInput/Chip.react.tsx
+++ b/src/UserInput/Chip.react.tsx
@@ -66,6 +66,7 @@ const Chip: React.FC<Props> = ({
       <TouchableOpacity
         style={[
           Styles.timeChipBackground,
+          !!image && { paddingVertical: 7 },
           square ? { borderRadius: 4 } : { borderRadius: 20 },
           backgroundStyle,
           style,

--- a/src/UserInput/Chip.react.tsx
+++ b/src/UserInput/Chip.react.tsx
@@ -66,7 +66,7 @@ const Chip: React.FC<Props> = ({
       <TouchableOpacity
         style={[
           Styles.timeChipBackground,
-          !!image && { paddingVertical: 7 },
+          !!image && { paddingVertical: 7 }, // The image is 2px taller than text so we conditionally bump the vertical padding down from the standard 8px to 7px
           square ? { borderRadius: 4 } : { borderRadius: 20 },
           backgroundStyle,
           style,


### PR DESCRIPTION
Sets the new vertical padding to 7px instead of the standard 8. This feels like a sad hack but I think is robust enough because the image height is always 20px and the difference of height is always 2 pixels.