### PR TITLE
In-text button spacing fix and new Storybook example

### DIFF
--- a/src/Common/InTextButtons.react.tsx
+++ b/src/Common/InTextButtons.react.tsx
@@ -40,24 +40,27 @@ const InTextButtons: React.FC<Props> = ({
     <Text style={containerStyle}>
       {calculatedBlocks.map((block, index) => {
         return (
-          <TouchableOpacity
-            disabled={block.type === "text"}
-            onPress={() => {
-              if (block.onPress) block.onPress();
-            }}
-            key={block.text + index.toString()}
-          >
-            <Body
-              style={
-                block.type === "text" ? textStyle || {} : buttonStyle || {}
-              }
-              bold={block.type === "button"}
-              numLines={1}
-              adjustSize
+          <Text>
+            <TouchableOpacity
+              disabled={block.type === "text"}
+              onPress={() => {
+                if (block.onPress) block.onPress();
+              }}
+              key={block.text + index.toString()}
             >
-              {block.text}{" "}
-            </Body>
-          </TouchableOpacity>
+              <Body
+                style={
+                  block.type === "text" ? textStyle || {} : buttonStyle || {}
+                }
+                bold={block.type === "button"}
+                numLines={1}
+                adjustSize
+              >
+                {block.text}
+              </Body>
+            </TouchableOpacity>
+            {" "}
+          </Text>
         );
       })}
     </Text>
@@ -69,6 +72,8 @@ InTextButtons.defaultProps = {
     textDecorationLine: "underline",
     color: Colors.BLUE_500,
     fontSize: 14,
+
+
   },
   textStyle: {
     fontSize: 14,

--- a/src/Common/InTextButtons.react.tsx
+++ b/src/Common/InTextButtons.react.tsx
@@ -72,8 +72,6 @@ InTextButtons.defaultProps = {
     textDecorationLine: "underline",
     color: Colors.BLUE_500,
     fontSize: 14,
-
-
   },
   textStyle: {
     fontSize: 14,

--- a/storybook/stories/Common/Common.stories.tsx
+++ b/storybook/stories/Common/Common.stories.tsx
@@ -26,6 +26,7 @@ import {
   withKnobs,
 } from "@storybook/addon-knobs";
 import TestIcon from "./TestIcon";
+import * as Colors from "@src/Brand/Colors";
 
 storiesOf("Common", module)
   .addDecorator((getStory) => <CenterView>{getStory()}</CenterView>)
@@ -112,17 +113,34 @@ storiesOf("Common", module)
   .add("InTextButtons", () => (
     <>
       <InTextButtons
-        buttonStyle={{
-          fontSize: 16,
-          textDecorationLine: "underline",
-        }}
         blocks={[
-          { type: "text", text: "text" },
+          { type: "text", text: "default-styled" },
           {
             type: "button",
             text: "button",
             onPress: () => { },
           },
+          { type: "text", text: "text" },
+        ]}
+      />
+      <InTextButtons
+        textStyle={{
+          fontSize: 16,
+        }}
+        buttonStyle={{
+          fontSize: 20,
+          color: Colors.GREEN_400,
+          fontFamily: "Inter_600SemiBold"
+        }}
+
+        blocks={[
+          { type: "text", text: "custom-styled" },
+          {
+            type: "button",
+            text: "button",
+            onPress: () => { },
+          },
+          { type: "text", text: "text" },
         ]}
       />
     </>


### PR DESCRIPTION
The component already supports custom-styling both the text and button. 

Fixed an issue that the space following the button-text was included in the button markup, making it look bad if underlined. 