### PR TITLE
prefer npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+dist/
 
 # macOS
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "version": "1.2.6",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@expo-google-fonts/inter": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json && copyfiles -u1 \"src/**/*.gif\" \"src/**/*.png\" dist",
     "clean": "rm -rf dist/",
-    "release": "yarn build && yarn publish && yarn clean",
+    "release": "npm run build && npm run publish && npm run clean",
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,7 +11,12 @@
     "sourceMap": true,
     "outDir": "dist",
     "rootDir": "src",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@src": ["src"],
+      "@src/*": ["src/*"]
+    }
   },
   "exclude": ["node_modules", "dist", "storybook", "App.tsx"],
   "includes": ["src", "./typings.d.ts"],


### PR DESCRIPTION
Cleaning up an outdated `yarn` reference. Ameelio's ecosystem leans heavily on the npm side.

I've also added support for @src to our `tsconfig.build.json` and ignored the `dist/` directory. Tiny things.